### PR TITLE
Downgrade Flutter version in GitHub Actions workflow

### DIFF
--- a/.github/workflows/flutter_android_build.yml
+++ b/.github/workflows/flutter_android_build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.27.0'
+          flutter-version: '3.22.0'
 
       - name: Install Dependencies
         run: flutter pub get


### PR DESCRIPTION
The Flutter version used in the GitHub Actions workflow for building Android APKs has been downgraded from '3.27.0' to '3.22.0'.