### PR TITLE
Fix: Resolve Android release keystore path

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -43,7 +43,10 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = file(keystoreProperties["storeFile"] as String)
+            val storeFilePath = keystoreProperties["storeFile"] as? String
+                ?: throw GradleException("Missing storeFile in key.properties")
+
+            storeFile = rootProject.file("android/$storeFilePath")
             storePassword = keystoreProperties["storePassword"] as String
             keyAlias = keystoreProperties["keyAlias"] as String
             keyPassword = keystoreProperties["keyPassword"] as String
@@ -59,7 +62,7 @@ android {
 //            signingConfig = signingConfigs.getByName("debug")
 
             signingConfig = signingConfigs.getByName("release")
-            
+
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
The `storeFile` path in `android/app/build.gradle.kts` was incorrectly specified, leading to build failures when attempting to sign the release APK.

This commit updates the path to correctly locate the keystore file relative to the root project directory, ensuring that `android/key.properties` correctly points to `android/keystore.jks`.

Additionally, a `GradleException` is now thrown if `storeFile` is missing from `key.properties`, providing clearer error feedback.