### PR TITLE
build: Add debug step to print key.properties in CI

### DIFF
--- a/.github/workflows/flutter_android_build.yml
+++ b/.github/workflows/flutter_android_build.yml
@@ -30,6 +30,7 @@ jobs:
           echo "keyPassword=${{ secrets.KEY_PASSWORD }}" >> android/key.properties
           echo "keyAlias=${{ secrets.KEY_ALIAS }}" >> android/key.properties
           echo "storeFile=keystore.jks" >> android/key.properties
+          cat android/key.properties
 
       - name: Build APK
         run: flutter build apk --release


### PR DESCRIPTION
This commit adds a `cat android/key.properties` command to the GitHub Actions workflow. This will print the contents of the `key.properties` file during the build process, which can be helpful for debugging purposes.