### PR TITLE
Refactor: Move keystore properties loading into signingConfigs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,11 +1,5 @@
 import java.util.Properties
 
-val keystoreProperties = Properties()
-val keystorePropertiesFile = rootProject.file("android/key.properties")
-if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(keystorePropertiesFile.inputStream())
-}
-
 plugins {
     id("com.android.application")
     // START: FlutterFire Configuration
@@ -43,6 +37,14 @@ android {
 
     signingConfigs {
         create("release") {
+            val keystoreProperties = Properties()
+            val keystorePropertiesFile = rootProject.file("android/key.properties")
+            if (keystorePropertiesFile.exists()) {
+                keystoreProperties.load(keystorePropertiesFile.inputStream())
+            } else {
+                throw GradleException("key.properties file not found at ${keystorePropertiesFile.path}")
+            }
+
             val storeFilePath = keystoreProperties["storeFile"] as? String
                 ?: throw GradleException("Missing storeFile in key.properties")
 


### PR DESCRIPTION
The loading of `keystoreProperties` and `keystorePropertiesFile` has been moved from the top-level of `android/app/build.gradle.kts` into the `signingConfigs { create("release") { ... } }` block.

Additionally, an explicit error is now thrown if `android/key.properties` is not found, improving error feedback during the build process.